### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Android CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/terry1921/android-template-2025/security/code-scanning/1](https://github.com/terry1921/android-template-2025/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal scopes needed by this workflow. Since the job only checks out code and builds/tests it, it only needs read access to repository contents; no write scopes or additional permissions appear necessary.

The best fix with minimal functional change is to add a `permissions` section at the workflow root level (just under `name:` and before `on:`) so that it applies to all jobs in the workflow. Set it to `contents: read`. This still allows `actions/checkout@v4` to fetch the repository while preventing the `GITHUB_TOKEN` from having unnecessary write capabilities. No imports or additional methods are required; this is purely a YAML configuration change in `.github/workflows/ci.yml`. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Android CI` and the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
